### PR TITLE
feat: 單詞查詢功能強化：中日解釋與發音功能

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,9 +1,52 @@
-async function translate(text, from, to, options) {
-    const { utils } = options;
+// 添加共用的請求體參數
+const COMMON_BODY = {
+    "_SessionToken": "r:ad1b6feaeaa641af4bdf839f302a522d",
+    "_ClientVersion": "js3.4.1",
+    "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
+    "g_os": "PCWeb",
+    "g_ver": "v4.9.5.20241220",
+    "_InstallationId": "1b2822a6-ede5-43e3-addb-00003642f992"
+};
+
+async function makeRequest(url, body, utils) {
     const { tauriFetch: fetch } = utils;
+    const headers = {
+        "Content-Type": "application/json;charset=UTF-8"
+    };
 
+    // 合併共用參數
+    const finalBody = { ...COMMON_BODY, ...body };
+
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: headers,
+        body: {
+            type: "Json",
+            payload: finalBody
+        }
+    });
+
+    if (!res.ok) {
+        throw `Http Request Error\nHttp Status: ${res.status}\n${JSON.stringify(res.data)}`;
+    }
+
+    return res.data;
+}
+
+async function getTTS(targetId, utils) {
+    const url = "https://api.mojidict.com/parse/functions/tts-fetch";
+    const body = {
+        "tarId": targetId,
+        "tarType": 102,
+        "voiceId": "f002"
+    };
+
+    const result = await makeRequest(url, body, utils);
+    return result.result?.result?.url;
+}
+
+async function translate(text, from, to, options) {
     const url = "https://api.mojidict.com/parse/functions/union-api";
-
     const body = {
         "functions": [
             {
@@ -13,65 +56,145 @@ async function translate(text, from, to, options) {
                     "types": [102, 106, 103],
                 },
             },
-        ],
-        "_ClientVersion": "js3.4.1",
-        "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
-        "g_os": "PCWeb",
-        "g_ver": "v4.8.8.20240829",
-        "_InstallationId": "1b2822a6-ede5-43e3-addb-00003642f992"
+        ]
     };
 
-    const headers = {
-        "Content-Type": "application/json;charset=UTF-8"
-    }
+    const result = await makeRequest(url, body, options.utils);
+    
+    if (result.result?.results?.["search-all"]?.result) {
+        let explanations = [];
+        let pronunciations = [];
+        const searchAllResult = result.result.results["search-all"].result;
+        let firstWord = null;
+        let detailsData = null;
+        let audioUrl = null;
+        let audioResponse = null;
 
-    const res = await fetch(url, {
-        method: 'POST',
-        headers: headers,
-        body: {
-            type: "Json",
-            payload: body
+        // 處理單詞
+        if (searchAllResult.word?.searchResult) {
+            explanations.push({ trait: "<単語>", explains: [""] });
+            
+            // 先獲取第一個單詞的詳細資訊
+            firstWord = searchAllResult.word.searchResult[0];
+            if (firstWord) {
+                const title = `${firstWord.spell || firstWord.title} | ${firstWord.pron || ''} ${firstWord.accent || ''}`.trim();
+                explanations.push({ 
+                    trait: "", 
+                    explains: [title, firstWord.excerpt],
+                    hasAudio: true  // 標記此項有音頻
+                });
+
+                // 獲取釋義
+                const targetId = firstWord.targetId;
+                if (targetId) {
+                    const detailsUrl = "https://api.mojidict.com/parse/functions/web-word-fetchLatest";
+                    const detailsBody = {
+                        "itemsJson": [
+                            {
+                                "objectId": targetId,
+                                "lfd": 0
+                            }
+                        ]
+                    };
+
+                    try {
+                        // 獲取詳細釋義
+                        detailsData = await makeRequest(detailsUrl, detailsBody, options.utils);
+                        
+                        // 處理 104 部分的資料（釋義）
+                        if (detailsData.result?.[104]) {
+                            const meanings = detailsData.result[104];
+                            const jaEntry = meanings.find(m => m.lang === "ja");
+                            const zhEntry = meanings.find(m => m.lang === "zh-CN");
+                            
+                            explanations.push({ trait: "-釈義-", explains: [""] });
+                            
+                            if (zhEntry) {
+                                explanations.push({ trait: "", explains: [`(中)${zhEntry.title}`] });
+                            } else {
+                                explanations.push({ trait: "", explains: ["(中)無中文释义"] });
+                            }
+                            if (jaEntry) {
+                                explanations.push({ trait: "", explains: [`(日)${jaEntry.title}`] });
+                            }
+                            
+                            explanations.push({ trait: "-釈義-", explains: [""] });
+                        }
+
+                        // 最後處理音頻
+                        audioUrl = await getTTS(targetId, options.utils);
+                        if (audioUrl) {
+                            try {
+                                const { fetch } = options.utils.http;
+                                audioResponse = await fetch(audioUrl, {
+                                    method: 'GET',
+                                    responseType: 3,  // 使用數字 3 表示 Binary
+                                    headers: {
+                                        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+                                    }
+                                });
+
+                                if (audioResponse.ok) {
+                                    const audioData = audioResponse.data;
+                                    if (audioData && audioData.length > 0) {
+                                        pronunciations.push({
+                                            region: "日本語",
+                                            symbol: firstWord.pron || "",
+                                            voice: audioData,
+                                            title: title
+                                        });
+                                    }
+                                }
+                            } catch (error) {
+                                console.error('Error fetching audio:', error);
+                            }
+                        }
+                    } catch (error) {
+                        console.error('Error fetching details:', error);
+                    }
+                }
+            }
+
+            // 處理其餘單詞
+            for (let i = 1; i < searchAllResult.word.searchResult.length; i++) {
+                const word = searchAllResult.word.searchResult[i];
+                const title = `${word.spell || word.title} | ${word.pron || ''} ${word.accent || ''}`.trim();
+                explanations.push({ trait: "", explains: [title, word.excerpt] });
+            }
+            
+            explanations.push({ trait: "", explains: [""] });
         }
-    });
 
-    if (res.ok) {
-        let result = res.data;
-        if (result.result?.results?.["search-all"]?.result) {
-            let explanations = [];
-            const searchAllResult = result.result.results["search-all"].result;
-
-            // 處理單詞
-            if (searchAllResult.word?.searchResult) {
-                explanations.push({ trait: "<単語>", explains: [""] });
-                for (let i of searchAllResult.word.searchResult) {
-                    explanations.push({ trait: "", explains: [i.title, i.excerpt] });
-                }
-                explanations.push({ trait: "", explains: [""] }); // 添加空行
+        // 處理文法
+        if (searchAllResult.grammar?.searchResult) {
+            explanations.push({ trait: "<文法>", explains: [""] });
+            for (let i of searchAllResult.grammar.searchResult) {
+                const title = i.title;
+                const explanation = i.excerpt.replace('[文法] ', '');
+                explanations.push({ trait: "", explains: [title, explanation] });
             }
-
-            // 處理文法
-            if (searchAllResult.grammar?.searchResult) {
-                explanations.push({ trait: "<文法>", explains: [""] });
-                for (let i of searchAllResult.grammar.searchResult) {
-                    explanations.push({ trait: "", explains: [i.title, i.excerpt.replace('[文法] ', '')] });
-                }
-                explanations.push({ trait: "", explains: [""] }); // 添加空行
-            }
-
-            // 處理例句
-            if (searchAllResult.example?.searchResult) {
-                explanations.push({ trait: "<例文>", explains: [""] });
-                for (let i of searchAllResult.example.searchResult) {
-                    explanations.push({ trait: "", explains: [i.title, i.excerpt] });
-                }
-            }
-
-            return { explanations, sentence: [] };
-        } else {
-            throw JSON.stringify(result);
+            explanations.push({ trait: "", explains: [""] });
         }
+
+        // 處理例句
+        if (searchAllResult.example?.searchResult) {
+            explanations.push({ trait: "<例文>", explains: [""] });
+            for (let i of searchAllResult.example.searchResult) {
+                explanations.push({ trait: "", explains: [i.title, i.excerpt] });
+            }
+        }
+
+        return { 
+            explanations, 
+            pronunciations,
+            sentence: [],
+            config: {
+                audioIcon: "🔊",  // 可以自定義音頻圖標
+                audioPosition: "after-title"  // 指定音頻按鈕位置
+            }
+        };
     } else {
-        throw `Http Request Error\nHttp Status: ${res.status}\n${JSON.stringify(res.data)}`;
+        throw JSON.stringify(result);
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -10,19 +10,21 @@ async function translate(text, from, to, options) {
                 "name": "search-all",
                 "params": {
                     "text": text,
-                    "types": [102],
+                    "types": [102, 106, 103],
                 },
             },
         ],
         "_ClientVersion": "js3.4.1",
         "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
         "g_os": "PCWeb",
-        "g_ver": "v4.6.4.20230615",
-        "_InstallationId": "1f7dbb56-9030-4f32-9645-0df69f86c591",
+        "g_ver": "v4.8.8.20240829",
+        "_InstallationId": "1b2822a6-ede5-43e3-addb-00003642f992"
     };
+
     const headers = {
         "Content-Type": "application/json;charset=UTF-8"
     }
+
     const res = await fetch(url, {
         method: 'POST',
         headers: headers,
@@ -34,16 +36,72 @@ async function translate(text, from, to, options) {
 
     if (res.ok) {
         let result = res.data;
-        if (result.result && result.result.results && result.result.results["search-all"] && result.result.results["search-all"].result && result.result.results["search-all"].result.word && result.result.results["search-all"].result.word.searchResult){
+        if (result.result?.results?.["search-all"]?.result) {
             let explanations = [];
-            for (let i of result.result.results["search-all"].result.word.searchResult) {
-                explanations.push({"trait":"","explains":[i.title, i.excerpt]});
+            const searchAllResult = result.result.results["search-all"].result;
+
+            // 處理單詞
+            if (searchAllResult.word?.searchResult) {
+                explanations.push({ trait: "<単語>", explains: [""] });
+                for (let i of searchAllResult.word.searchResult) {
+                    explanations.push({ trait: "", explains: [i.title, i.excerpt] });
+                }
+                explanations.push({ trait: "", explains: [""] }); // 添加空行
             }
-            return {explanations};
-        }else{
+
+            // 處理文法
+            if (searchAllResult.grammar?.searchResult) {
+                explanations.push({ trait: "<文法>", explains: [""] });
+                for (let i of searchAllResult.grammar.searchResult) {
+                    explanations.push({ trait: "", explains: [i.title, i.excerpt.replace('[文法] ', '')] });
+                }
+                explanations.push({ trait: "", explains: [""] }); // 添加空行
+            }
+
+            // 處理例句
+            if (searchAllResult.example?.searchResult) {
+                explanations.push({ trait: "<例文>", explains: [""] });
+                for (let i of searchAllResult.example.searchResult) {
+                    explanations.push({ trait: "", explains: [i.title, i.excerpt] });
+                }
+            }
+
+            return { explanations, sentence: [] };
+        } else {
             throw JSON.stringify(result);
         }
     } else {
         throw `Http Request Error\nHttp Status: ${res.status}\n${JSON.stringify(res.data)}`;
     }
+}
+
+function formatResults(section, trait, formatFunc) {
+    if (!section || !section.searchResult) return [];
+    
+    const formattedResults = formatFunc(section.searchResult);
+    return [
+        { trait, explains: formattedResults },
+        { trait: "", explains: [""] } // 添加空行
+    ];
+}
+
+function formatWordResults(wordResults) {
+    return wordResults.map(item => ({
+        trait: item.title,
+        explains: [item.excerpt]
+    }));
+}
+
+function formatGrammarResults(grammarResults) {
+    return grammarResults.map(item => ({
+        trait: item.title,
+        explains: [item.excerpt.replace('[文法] ', '')]
+    }));
+}
+
+function formatExampleResults(exampleResults) {
+    return exampleResults.map(item => ({
+        trait: item.title,
+        explains: [item.excerpt]
+    }));
 }


### PR DESCRIPTION
## 功能說明
1. 新增中日文解釋，支援中日文單詞對照
2. 新增 moji 發音的音訊播放按鈕，點擊即可播放單字發音

## 技術改進
- 重構 API 請求邏輯，建立通用請求處理函數
- 整合音訊播放功能
- 優化資料處理流程
- 改善錯誤處理機制
- 重組搜尋結果的展示結構

## 實現效果
![image](https://github.com/user-attachments/assets/d468dcf6-6d29-476d-b2c1-e0572e081119)

https://github.com/user-attachments/assets/ee763c2d-0f40-4669-bd95-3193db57bbdd

Closes #3 